### PR TITLE
Update CI workflow to remove Windows support and adjust Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.11', '3.13']
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.9', '3.13']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Remove Windows support from the CI workflow and limit the Python versions to 3.9 and 3.13.